### PR TITLE
feat(atlantis): fix migrations

### DIFF
--- a/migrations.tf
+++ b/migrations.tf
@@ -23,8 +23,3 @@ moved {
   from = aws_iam_role.this[0]
   to   = module.addon-irsa["atlantis"].aws_iam_role.irsa[0]
 }
-
-moved {
-  from = aws_iam_role_policy_attachment.this_additional
-  to   = module.addon-irsa["atlantis"].aws_iam_role_policy_attachment.irsa_additional
-}


### PR DESCRIPTION
# Description

Remove migration which is causing the error in naming.
Manual steps will be needed like:
 terraform state rm 'module.atlantis.module.addon-irsa["atlantis"].aws_iam_role_policy_attachment.irsa_additional["AssumeAtlantisWorkers"]'
 
 terraform import 'module.atlantis.aws_iam_role_policy_attachment.this_additional["AssumeAtlantisWorkers"]'

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->
